### PR TITLE
Revert "Use overlayfs"

### DIFF
--- a/roles/docker/files/10-docker.conf
+++ b/roles/docker/files/10-docker.conf
@@ -1,4 +1,3 @@
 [Service]
 ExecStart=
-# storage-driver=overlay because kernel deadlocks when using aufs
-ExecStart=/usr/bin/dockerd --log-opt max-size=100m --log-opt max-file=10  -H fd:// --log-level=warn --bridge=none --iptables=false --ip-masq=false -g /mnt/containers/docker --storage-driver=overlay
+ExecStart=/usr/bin/dockerd --log-opt max-size=100m --log-opt max-file=10  -H fd:// --log-level=warn --bridge=none --iptables=false --ip-masq=false -g /mnt/containers/docker


### PR DESCRIPTION
Reverts weaveworks/ansible-kubernetes#1 — should have been overlay2