### PR TITLE
Support multiple concurrent k8s versions

### DIFF
--- a/roles/kubelet/tasks/main.yaml
+++ b/roles/kubelet/tasks/main.yaml
@@ -13,8 +13,8 @@
 - name: install common kubernetes components
   apt: name={{item}} state=present update_cache=yes
   with_items:
-    - kubelet={{kubernetes_version}}
-    - kubernetes-cni={{kubernetes_cni_version}}
+    - kubelet={{kubernetes_versions[hostk8s|default(defaultk8s)]["kubelet"]}}
+    - kubernetes-cni={{kubernetes_versions[hostk8s|default(defaultk8s)]["cni"]}}
 
 - name: mkdir /etc/systemd/system/kubelet.service.d
   file: path=/etc/systemd/system/kubelet.service.d state=directory

--- a/roles/kubelet/tasks/main.yaml
+++ b/roles/kubelet/tasks/main.yaml
@@ -11,7 +11,7 @@
   apt_repository: repo='deb http://weaveworks-apt-repo.s3-website-us-east-1.amazonaws.com/ stable main' state=present
 
 - name: install common kubernetes components
-  apt: name={{item}} state=present update_cache=no
+  apt: name={{item}} state=present update_cache=yes
   with_items:
     - kubelet={{kubernetes_version}}
     - kubernetes-cni={{kubernetes_cni_version}}

--- a/roles/kubernetes-master/templates/kube-apiserver.yaml
+++ b/roles/kubernetes-master/templates/kube-apiserver.yaml
@@ -8,7 +8,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-apiserver
-    image: gcr.io/google_containers/kube-apiserver-amd64:{{ kubernetes_image_version }}
+    image: gcr.io/google_containers/kube-apiserver-amd64:{{ kubernetes_versions[hostk8s|default(defaultk8s)]["images"] }}
     command:
     - /usr/local/bin/kube-apiserver
     args:

--- a/roles/kubernetes-master/templates/kube-controller-manager.yaml
+++ b/roles/kubernetes-master/templates/kube-controller-manager.yaml
@@ -10,7 +10,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-controller-manager
-    image: gcr.io/google_containers/kube-controller-manager-amd64:{{ kubernetes_image_version }}
+    image: gcr.io/google_containers/kube-controller-manager-amd64:{{ kubernetes_versions[hostk8s|default(defaultk8s)]["images"] }}
     command:
     - /usr/local/bin/kube-controller-manager
     args:

--- a/roles/kubernetes-master/templates/kube-scheduler.yaml
+++ b/roles/kubernetes-master/templates/kube-scheduler.yaml
@@ -10,7 +10,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-scheduler
-    image: gcr.io/google_containers/kube-scheduler-amd64:{{ kubernetes_image_version }}
+    image: gcr.io/google_containers/kube-scheduler-amd64:{{ kubernetes_versions[hostk8s|default(defaultk8s)]["images"] }}
     command:
     - /usr/local/bin/kube-scheduler
     args:

--- a/roles/kubernetes-minion/templates/kube-proxy.yaml
+++ b/roles/kubernetes-minion/templates/kube-proxy.yaml
@@ -12,7 +12,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-proxy
-    image: gcr.io/google_containers/kube-proxy-amd64:{{ kubernetes_image_version }}
+    image: gcr.io/google_containers/kube-proxy-amd64:{{ kubernetes_versions[hostk8s|default(defaultk8s)]["images"] }}
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
This change extends the playbooks to allow multiple kubernetes versions to
exist in a cluster concurrently, to support safe rolling upgrades. To achieve
this the simple variables:

```
kubernetes_version: 1.4.8-00
kubernetes_cni_version: 0.3.0.1-07a8a2-00
kubernetes_image_version: v1.4.8
```

Are replaced by a map and a default selector:

```
defaultk8s: 1.4.8
kubernetes_versions:
  1.4.8:
    kubelet : 1.4.8-00
    cni: 0.3.0.1-07a8a2-00
    images: v1.4.8
```

Furthermore, this default can be overriden on a per-host basis in the inventory
file by specifying a `hostk8s=x.y.z` variable that selects a different key from
the map. With this mechanism in place, it is possible to upgrade a cluster
incrementally, applying the site playbook to all hosts at each stage, ensuring
the site configuration specification does not diverge from the cluster state.