### PR TITLE
Be explicit about storage backend configuration

### DIFF
--- a/roles/kubernetes-master/templates/kube-apiserver.yaml
+++ b/roles/kubernetes-master/templates/kube-apiserver.yaml
@@ -30,6 +30,10 @@ spec:
     - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota
     - --allow-privileged
 
+    # Override new k8s 1.6 defaults
+    - --storage-backend=etcd2
+    - --storage-media-type=application/json
+
     resources:
       requests:
         cpu: 250m


### PR DESCRIPTION
Kubernetes 1.6 changes the defaults for the following arguments:

    --storage-backend etcd2 -> etcd3
    --storage-media-type application/json -> application/vnd.kubernetes.protobuf

The etcd version & storage format migration require special handling
that we want to tackle _after_ the upgrade to 1.6, so we have to be
explicit about the current settings beforehand.