### PR TITLE
Remove unnecessary kubelet args

### DIFF
--- a/roles/kubelet/templates/10-kubelet.conf
+++ b/roles/kubelet/templates/10-kubelet.conf
@@ -1,3 +1,3 @@
 [Service]
 ExecStart=
-ExecStart=/usr/bin/kubelet --v=4 --kubeconfig=/etc/kubernetes/kubelet.conf --require-kubeconfig=true --pod-manifest-path=/etc/kubernetes/manifests --allow-privileged=true --cgroup-root=docker --cluster-dns={{ cluster_dns_ip }} --cluster-domain=cluster.local --network-plugin=kubenet --reconcile-cidr --non-masquerade-cidr={{ pod_cidr }} --cloud-provider=aws --root-dir=/mnt/containers/kubernetes --pod-cidr={{ static_pod_cidr }}
+ExecStart=/usr/bin/kubelet --v=4 --kubeconfig=/etc/kubernetes/kubelet.conf --require-kubeconfig=true --pod-manifest-path=/etc/kubernetes/manifests --allow-privileged=true --cluster-dns={{ cluster_dns_ip }} --cluster-domain=cluster.local --network-plugin=kubenet --non-masquerade-cidr={{ pod_cidr }} --cloud-provider=aws --root-dir=/mnt/containers/kubernetes --pod-cidr={{ static_pod_cidr }}


### PR DESCRIPTION
The following arguments are redundant in our use of kubelet 1.5 and
actively prevent 1.6 from working:

* `--reconcile-cidr` is deprecated in 1.5 and removed in 1.6
* `--cgroup-root=docker` is unnecessary in 1.5 and interferes with CRI
  operation in 1.6